### PR TITLE
Fixed bug when types were serialized wrong for elastic search with active record queries

### DIFF
--- a/lib/logstasher/active_record/log_subscriber.rb
+++ b/lib/logstasher/active_record/log_subscriber.rb
@@ -26,11 +26,11 @@ module LogStasher
 
         return if 'SCHEMA' == data[:name]
 
+        data = extract_sql(data)
         data.merge! runtimes(event)
-        data.merge! extract_sql(data)
         data.merge! request_context
         data.merge! LogStasher.store
-        data.merge! extract_custom_fields(data)
+        data.merge! extract_custom_fields(event.payload)
 
         tags = [ 'request' ]
         tags.push('exception') if data[:exception]


### PR DESCRIPTION
Problem was that all attributes (also data attributes) are serialized and that leads to parser errors on logstash side when it was pushed to ES.